### PR TITLE
xray_config.json: Rounting bug fixed

### DIFF
--- a/fully-single-port/xray_config.json
+++ b/fully-single-port/xray_config.json
@@ -203,29 +203,27 @@
     ],
     "routing": {
         "domainStrategy": "AsIs",
-        "settings": {
-            "rules": [
-                {
-                    "type": "field",
-                    "outboundTag": "blackhole",
-                    "ip": [
-                        "geoip:private"
-                    ]
-                },
-                {
-                    "type": "field",
-                    "port": 53,
-                    "network": "tcp,udp",
-                    "outboundTag": "DNS-Internal"
-                },
-                {
-                    "type": "field",
-                    "outboundTag": "blackhole",
-                    "protocol": [
-                        "bittorrent"
-                    ]
-                }
-            ]
-        }
+        "rules": [
+            {
+                "type": "field",
+                "outboundTag": "blackhole",
+                "ip": [
+                    "geoip:private"
+                ]
+            },
+            {
+                "type": "field",
+                "port": 53,
+                "network": "tcp,udp",
+                "outboundTag": "DNS-Internal"
+            },
+            {
+                "type": "field",
+                "outboundTag": "blackhole",
+                "protocol": [
+                    "bittorrent"
+                ]
+            }
+        ]
     }
 }

--- a/single-port-proxy/xray_config.json
+++ b/single-port-proxy/xray_config.json
@@ -203,29 +203,27 @@
     ],
     "routing": {
         "domainStrategy": "AsIs",
-        "settings": {
-            "rules": [
-                {
-                    "type": "field",
-                    "outboundTag": "blackhole",
-                    "ip": [
-                        "geoip:private"
-                    ]
-                },
-                {
-                    "type": "field",
-                    "port": 53,
-                    "network": "tcp,udp",
-                    "outboundTag": "DNS-Internal"
-                },
-                {
-                    "type": "field",
-                    "outboundTag": "blackhole",
-                    "protocol": [
-                        "bittorrent"
-                    ]
-                }
-            ]
-        }
+        "rules": [
+            {
+                "type": "field",
+                "outboundTag": "blackhole",
+                "ip": [
+                    "geoip:private"
+                ]
+            },
+            {
+                "type": "field",
+                "port": 53,
+                "network": "tcp,udp",
+                "outboundTag": "DNS-Internal"
+            },
+            {
+                "type": "field",
+                "outboundTag": "blackhole",
+                "protocol": [
+                    "bittorrent"
+                ]
+            }
+        ]
     }
 }


### PR DESCRIPTION
The "rules" block was placed incorrectly inside an object named "settings", and it caused the routing settings not to be applied. But without the "settings" block everything works fine.